### PR TITLE
hotfix(build): clean cache while building with gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,14 @@
+# Gradle Build Settings
+# For local development with watch-and-reload.sh
+
+# Disable build cache for immediate file change detection
+org.gradle.caching=false
+
+# Disable daemon for fresh JVM on each build
+org.gradle.daemon=false
+
+# Disable parallel builds for stability
+org.gradle.parallel=false
+
+# JVM memory settings
+org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=256m

--- a/watch-and-reload.sh
+++ b/watch-and-reload.sh
@@ -3,7 +3,7 @@
 echo "Starting watch mode for Java files..."
 
 # 초기 빌드
-gradle bootJar -x test
+./gradlew clean bootJar -x test
 
 # JAR 파일 경로 확인
 JAR_PATH=$(find build/libs -name "*.jar" | grep -v plain | head -1)
@@ -11,7 +11,7 @@ echo "JAR 파일: $JAR_PATH"
 
 # JAR 파일이 존재하는지 확인
 if [ ! -f "$JAR_PATH" ]; then
-  echo "ERROR: 실행 가능한 JAR를 찾을 수 없습니다. 정확한 빌드를 확인하세요."
+  echo "ERROR: 실행 가능한 JAR를 찾을 수 없습니다."
   ls -la build/libs/
   exit 1
 fi
@@ -19,6 +19,7 @@ fi
 # 현재 소스 파일의 상태 저장
 mkdir -p /tmp/file-hashes
 find src/main/java -name "*.java" -type f -exec md5sum {} \; > /tmp/file-hashes/previous.md5
+find src/main/resources -name "*.yml" -o -name "*.properties" -type f -exec md5sum {} \; >> /tmp/file-hashes/previous.md5
 
 # 최초 실행
 echo "애플리케이션 시작 중..."
@@ -32,22 +33,24 @@ trap "kill $APP_PID; exit" SIGINT SIGTERM
 while true; do
   # 현재 파일 해시 생성
   find src/main/java -name "*.java" -type f -exec md5sum {} \; > /tmp/file-hashes/current.md5
+  find src/main/resources -name "*.yml" -o -name "*.properties" -type f -exec md5sum {} \; >> /tmp/file-hashes/current.md5
 
   # 해시 비교로 변경된 파일 확인
   DIFF=$(diff /tmp/file-hashes/previous.md5 /tmp/file-hashes/current.md5)
 
   if [ -n "$DIFF" ]; then
+    echo "================================"
     echo "파일 변경 감지됨!"
     echo "$DIFF"
-    echo "애플리케이션 재빌드 중..."
-    ]
+    echo "================================"
 
     # 이전 프로세스 종료
     kill $APP_PID 2>/dev/null
     wait $APP_PID 2>/dev/null
 
     # 새로 빌드
-    gradle bootJar -x test
+    echo "애플리케이션 재빌드 중..."
+    ./gradlew clean bootJar -x test
 
     # JAR 파일 경로 업데이트
     JAR_PATH=$(find build/libs -name "*.jar" | grep -v plain | head -1)
@@ -66,6 +69,9 @@ while true; do
 
     # 현재 해시 저장
     cp /tmp/file-hashes/current.md5 /tmp/file-hashes/previous.md5
+    
+    echo "애플리케이션이 재시작되었습니다. (PID: $APP_PID)"
+    echo "================================"
   fi
 
   # 대기 시간


### PR DESCRIPTION
# Ticket

task-x-x-x

# Slack

<!-- 작업과 관련된 슬랙 스레드 링크를 입력해주세요. -->
<!-- [Slack Thread](...) -->

# Description

Gradle cache 때문에 live reload시 최신 코드 반영이 안되는 문제를 해결해요.

# Checklist

<!-- 머지하기 전 확인해야 할 사항을 체크해주세요. -->