### PR TITLE
fix: increase docker HEALTHCHECK timeouts to fix failing ECS deployments

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -29,7 +29,7 @@ ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -Djava.securit
 COPY --from=build --chown=appuser:appgroup /app/build/libs/*.jar app.jar
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 CMD wget --quiet --tries=1 --spider http://localhost:8080/api/v1/health || exit 1
+HEALTHCHECK --interval=60s --timeout=5s --start-period=180s --retries=3 CMD wget --quiet --tries=1 --spider http://localhost:8080/api/v1/health || exit 1
 
 # Expose application port
 EXPOSE 8080


### PR DESCRIPTION
# Ticket

task-x-x-x

# Slack


# Description

스프링이 정상 빌드(약 60초 소요)되었는데도 간헐적으로 헬스체크 시간이 안 맞아 배포 실패하는 오류가 발생합니다. 해당 오류를 줄이기 위해 헬스체크 start-period 및 timeout을 안정적으로 늘렸습니다. 

# Checklist

다시 테스트 해보니 아래 방법이 훨씬 문제해결에 절대적이었어서(일단 지금은 배포 잘 된 상태) 
*관련해서 ALB 설정 수정 (정상 임계 값:5->2 연속 상태 검사 성공, 상태 검사 간격 30초->60초)
*관련해서 ECS 서비스 설정 수정(최소 실행 작업 비율 100%->50%로 task 무한 재시도 루프 시간 적도록)
hotfix는 아닌 것 같은데, 저는 개발 과정에서 Dockerfile start-period도 조절해서 더 안정적으로 가도 될 것 같습니다. 

혹은 제가 잘못 이해한 것 같으면 의견 부탁드립니다!