### PR TITLE
cd(api): add api-server deployment workflow

### DIFF
--- a/.github/workflows/deploy-api-server-dev.yml
+++ b/.github/workflows/deploy-api-server-dev.yml
@@ -3,7 +3,7 @@ name: Dev - Deploy API Server to ECS
 on:
   push:
     tags:
-      - 'deploy-api-server-[0-9]*.[0-9]*.[0-9]*-dev'
+      - 'deploy-api-server-[0-9]+.[0-9]+.[0-9]+-dev'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-api-server-dev.yml
+++ b/.github/workflows/deploy-api-server-dev.yml
@@ -82,6 +82,25 @@ jobs:
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
 
+      - name: Confirm task definition actually deployed
+        id: confirm-deploy
+        run: |
+          LATEST_REVISION=$(aws ecs describe-task-definition --task-definition ${{ env.TASK_DEFINITION_FAMILY }} \
+            --query "taskDefinition.revision" --output text)
+
+          DEPLOYED_REVISION=$(aws ecs describe-services \
+            --cluster ${{ env.ECS_CLUSTER }} \
+            --services ${{ env.ECS_SERVICE }} \
+            --query "services[0].deployments[?status=='PRIMARY'].taskDefinition" --output text | awk -F: '{print $NF}')
+
+          echo "latest=$LATEST_REVISION" >> $GITHUB_OUTPUT
+          echo "deployed=$DEPLOYED_REVISION" >> $GITHUB_OUTPUT
+
+          if [ "$LATEST_REVISION" != "$DEPLOYED_REVISION" ]; then
+            echo "::error title=Deployment Rollback::ECS rolled back to previous task definition"
+            exit 1
+          fi
+
       - name: Notify Slack on Success
         if: success()
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/deploy-api-server-dev.yml
+++ b/.github/workflows/deploy-api-server-dev.yml
@@ -2,6 +2,8 @@ name: Dev - Deploy API Server to ECS
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'src/**'
       - 'Dockerfile.prod'

--- a/.github/workflows/deploy-api-server-dev.yml
+++ b/.github/workflows/deploy-api-server-dev.yml
@@ -1,11 +1,11 @@
-name: Dev - Deploy Backend to ECS
+name: Dev - Deploy API Server to ECS
 
 on:
   push:
     paths:
       - 'src/**'
       - 'Dockerfile.prod'
-      - '.github/workflows/deploy-backend-dev.yml'
+      - '.github/workflows/deploy-api-server-dev.yml'
   workflow_dispatch:
 
 env:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy Backend to ECS
+    name: Deploy API Server to ECS
     runs-on: ubuntu-latest
 
     steps:
@@ -93,7 +93,7 @@ jobs:
               "attachments": [
                 {
                   "color": "good",
-                  "title": "✅ Deployment Success: Backend -> ECS",
+                  "title": "✅ Deployment Success: API Server -> ECS",
                   "fields": [
                     {
                       "title": "Repository",
@@ -141,7 +141,7 @@ jobs:
               "attachments": [
                 {
                   "color": "danger",
-                  "title": "❌ Deployment Failed: Backend -> ECS",
+                  "title": "❌ Deployment Failed: API Server -> ECS",
                   "fields": [
                     {
                       "title": "Repository",

--- a/.github/workflows/deploy-api-server-dev.yml
+++ b/.github/workflows/deploy-api-server-dev.yml
@@ -2,12 +2,8 @@ name: Dev - Deploy API Server to ECS
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'Dockerfile.prod'
-      - '.github/workflows/deploy-api-server-dev.yml'
+    tags:
+      - 'deploy-api-server-[0-9]*.[0-9]*.[0-9]*-dev'
   workflow_dispatch:
 
 env:
@@ -27,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -51,16 +47,21 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build, tag, and push Docker image to ECR
+      - name: Extract version from deployment tag
+        id: get-version
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          VERSION=$(echo $TAG_NAME | sed -E 's/deploy-api-server-([0-9]+\.[0-9]+\.[0-9]+)-dev/\1/')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT 
+
+      - name: Build, tag Docker image, and push it to ECR
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: dev-${{ github.sha }}
+          IMAGE_TAG: dev-api-server-${{ steps.get-version.outputs.version }}
         run: |
           docker build -f Dockerfile.prod -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:dev
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:dev
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG 
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Download current task definition
@@ -122,8 +123,8 @@ jobs:
                       "short": true
                     },
                     {
-                      "title": "Branch",
-                      "value": "main",
+                      "title": "Version",
+                      "value": "${{ steps.get-version.outputs.version }}", 
                       "short": true
                     },
                     {
@@ -133,18 +134,23 @@ jobs:
                     },
                     {
                       "title": "Image Tag",
-                      "value": "dev-${{ github.sha }}",
+                      "value": "dev-api-server-${{ steps.get-version.outputs.version }}",
                       "short": true
                     },
                     {
                       "title": "Actor",
                       "value": "${{ github.actor }}",
                       "short": true
+                    },
+                    {
+                      "title": "Action URL",
+                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "short": false
                     }
                   ],
                   "footer": "GitHub Actions",
                   "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-                  "ts": "${{ github.event.repository.updated_at }}"
+                  "ts": "${{ steps.current-time.outputs.time }}"
                 }
               ]
             }
@@ -170,14 +176,19 @@ jobs:
                       "short": true
                     },
                     {
-                      "title": "Branch",
-                      "value": "main",
+                      "title": "Version",
+                      "value": "${{ steps.get-version.outputs.version }}",
                       "short": true
                     },
                     {
                       "title": "Commit Message",
                       "value": "${{ github.event.head_commit.message }}",
                       "short": false
+                    },
+                    {
+                      "title": "Image Tag", 
+                      "value": "dev-api-server-${{ steps.get-version.outputs.version }}",
+                      "short": true
                     },
                     {
                       "title": "Actor",
@@ -192,7 +203,7 @@ jobs:
                   ],
                   "footer": "GitHub Actions",
                   "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
-                  "ts": "${{ github.event.repository.updated_at }}"
+                  "ts": "${{ steps.current-time.outputs.time }}"
                 }
               ]
             }

--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -1,0 +1,189 @@
+name: Dev - Deploy Backend to ECS
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'Dockerfile.prod'
+      - '.github/workflows/deploy-backend-dev.yml'
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: study_aid/backend
+  ECS_CLUSTER: study_aid
+  ECS_SERVICE: studyaid-dev-ecs-service
+  CONTAINER_NAME: api-server
+  TASK_DEFINITION_FAMILY: backend
+
+jobs:
+  deploy:
+    name: Deploy Backend to ECS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew build -Pprofile=dev
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push Docker image to ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: dev-${{ github.sha }}
+        run: |
+          docker build -f Dockerfile.prod -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:dev
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:dev
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition --task-definition ${{ env.TASK_DEFINITION_FAMILY }} \
+          --query taskDefinition > task-definition.json
+
+      - name: Add log configuration to task definition 
+        run: | 
+          jq '.containerDefinitions[0].logConfiguration = { 
+            logDriver: "awslogs", 
+            options: { 
+              "awslogs-group": "/ecs/backend", 
+              "awslogs-region": "ap-northeast-2", 
+              "awslogs-stream-prefix": "api-server" 
+            } 
+          }' task-definition.json > task-definition-with-logs.json 
+
+      - name: Update container image in task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition-with-logs.json # 
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy to Amazon ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      - name: Notify Slack on Success
+        if: success()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,repo,commit,message
+          custom_payload: |
+            {
+              "attachments": [
+                {
+                  "color": "good",
+                  "title": "✅ 배포 성공: Backend -> ECS",
+                  "fields": [
+                    {
+                      "title": "레포지토리",
+                      "value": "${{ github.repository }}",
+                      "short": true
+                    },
+                    {
+                      "title": "브랜치",
+                      "value": "main",
+                      "short": true
+                    },
+                    {
+                      "title": "커밋 메시지",
+                      "value": "${{ github.event.head_commit.message }}",
+                      "short": false
+                    },
+                    {
+                      "title": "이미지 태그",
+                      "value": "dev-${{ github.sha }}",
+                      "short": true
+                    },
+                    {
+                      "title": "작업자",
+                      "value": "${{ github.actor }}",
+                      "short": true
+                    }
+                  ],
+                  "footer": "GitHub Actions",
+                  "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                  "ts": "${{ github.event.repository.updated_at }}"
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,repo,commit,message
+          custom_payload: |
+            {
+              "attachments": [
+                {
+                  "color": "danger",
+                  "title": "❌ 배포 실패: Backend -> ECS",
+                  "fields": [
+                    {
+                      "title": "레포지토리",
+                      "value": "${{ github.repository }}",
+                      "short": true
+                    },
+                    {
+                      "title": "브랜치",
+                      "value": "main",
+                      "short": true
+                    },
+                    {
+                      "title": "커밋 메시지",
+                      "value": "${{ github.event.head_commit.message }}",
+                      "short": false
+                    },
+                    {
+                      "title": "작업자",
+                      "value": "${{ github.actor }}",
+                      "short": true
+                    },
+                    {
+                      "title": "Actions 링크",
+                      "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "short": false
+                    }
+                  ],
+                  "footer": "GitHub Actions",
+                  "footer_icon": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                  "ts": "${{ github.event.repository.updated_at }}"
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -2,12 +2,11 @@ name: Dev - Deploy Backend to ECS
 
 on:
   push:
-    branches:
-      - main
     paths:
       - 'src/**'
       - 'Dockerfile.prod'
       - '.github/workflows/deploy-backend-dev.yml'
+  workflow_dispatch:
 
 env:
   AWS_REGION: ap-northeast-2
@@ -25,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -65,22 +66,11 @@ jobs:
           aws ecs describe-task-definition --task-definition ${{ env.TASK_DEFINITION_FAMILY }} \
           --query taskDefinition > task-definition.json
 
-      - name: Add log configuration to task definition 
-        run: | 
-          jq '.containerDefinitions[0].logConfiguration = { 
-            logDriver: "awslogs", 
-            options: { 
-              "awslogs-group": "/ecs/backend", 
-              "awslogs-region": "ap-northeast-2", 
-              "awslogs-stream-prefix": "api-server" 
-            } 
-          }' task-definition.json > task-definition-with-logs.json 
-
       - name: Update container image in task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
-          task-definition: task-definition-with-logs.json # 
+          task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.build-image.outputs.image }}
 
@@ -103,30 +93,30 @@ jobs:
               "attachments": [
                 {
                   "color": "good",
-                  "title": "✅ 배포 성공: Backend -> ECS",
+                  "title": "✅ Deployment Success: Backend -> ECS",
                   "fields": [
                     {
-                      "title": "레포지토리",
+                      "title": "Repository",
                       "value": "${{ github.repository }}",
                       "short": true
                     },
                     {
-                      "title": "브랜치",
+                      "title": "Branch",
                       "value": "main",
                       "short": true
                     },
                     {
-                      "title": "커밋 메시지",
+                      "title": "Commit Message",
                       "value": "${{ github.event.head_commit.message }}",
                       "short": false
                     },
                     {
-                      "title": "이미지 태그",
+                      "title": "Image Tag",
                       "value": "dev-${{ github.sha }}",
                       "short": true
                     },
                     {
-                      "title": "작업자",
+                      "title": "Actor",
                       "value": "${{ github.actor }}",
                       "short": true
                     }
@@ -151,30 +141,30 @@ jobs:
               "attachments": [
                 {
                   "color": "danger",
-                  "title": "❌ 배포 실패: Backend -> ECS",
+                  "title": "❌ Deployment Failed: Backend -> ECS",
                   "fields": [
                     {
-                      "title": "레포지토리",
+                      "title": "Repository",
                       "value": "${{ github.repository }}",
                       "short": true
                     },
                     {
-                      "title": "브랜치",
+                      "title": "Branch",
                       "value": "main",
                       "short": true
                     },
                     {
-                      "title": "커밋 메시지",
+                      "title": "Commit Message",
                       "value": "${{ github.event.head_commit.message }}",
                       "short": false
                     },
                     {
-                      "title": "작업자",
+                      "title": "Actor",
                       "value": "${{ github.actor }}",
                       "short": true
                     },
                     {
-                      "title": "Actions 링크",
+                      "title": "Action URL",
                       "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
                       "short": false
                     }


### PR DESCRIPTION
# Ticket

task-0-3-2

# Slack


# Description

api-server 배포 자동화 코드 작성 및 슬랙 앱 연동
(테스트 완료, 5월 18일 새벽 기준 main 최신 버전으로 배포 완료된 상태입니다.)

# Checklist

Langchain 서버 관련한 것은 QnA 리팩 마무리한 다음 ECS 태스크 정의 다시 하고 따로 PR 올리겠습니다. 
일단 main 브랜치 푸쉬할 때만 트리거 되게 하고, checkout도 main 브랜치로만 하고 혹시나 해서 수동 배포도 가능하게(workflow_dispatch) 했는데 이렇게 하는 거 맞을까요? 의견 주시면 감사하겠습니다!