### PR TITLE
fix(cd): handle multiline commit messages when sending slack webhook

### DIFF
--- a/.github/workflows/deploy-api-server-dev.yml
+++ b/.github/workflows/deploy-api-server-dev.yml
@@ -129,7 +129,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -182,7 +182,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {

--- a/.github/workflows/deploy-generate-exam-dev.yml
+++ b/.github/workflows/deploy-generate-exam-dev.yml
@@ -101,7 +101,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -159,7 +159,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {

--- a/.github/workflows/deploy-generate-exam-prod.yml
+++ b/.github/workflows/deploy-generate-exam-prod.yml
@@ -102,7 +102,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -160,7 +160,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {

--- a/.github/workflows/deploy-generate-quiz-dev.yml
+++ b/.github/workflows/deploy-generate-quiz-dev.yml
@@ -101,7 +101,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -159,7 +159,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {

--- a/.github/workflows/deploy-generate-quiz-prod.yml
+++ b/.github/workflows/deploy-generate-quiz-prod.yml
@@ -102,7 +102,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -160,7 +160,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {

--- a/.github/workflows/deploy-summarize-lecture-dev.yml
+++ b/.github/workflows/deploy-summarize-lecture-dev.yml
@@ -101,7 +101,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -159,7 +159,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {

--- a/.github/workflows/deploy-summarize-lecture-prod.yml
+++ b/.github/workflows/deploy-summarize-lecture-prod.yml
@@ -102,7 +102,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {
@@ -160,7 +160,7 @@ jobs:
                     },
                     {
                       "title": "Commit Message",
-                      "value": "${{ github.event.head_commit.message }}",
+                      "value": ${{ toJSON(github.event.head_commit.message) }},
                       "short": false
                     },
                     {


### PR DESCRIPTION
# Ticket

task-x-x-x

# Slack

<!-- 작업과 관련된 슬랙 스레드 링크를 입력해주세요. -->
<!-- [Slack Thread](...) -->

# Description

Slack 메시지 보낼 때 commit message가 multiline 인 경우를 핸들링해요.

# Checklist

<!-- 머지하기 전 확인해야 할 사항을 체크해주세요. -->