### PR TITLE
feat: change QuizResult creation timing with 'partially_graded' status

### DIFF
--- a/flyway/migrations/V10__add_partially_graded_status_to_quiz_table.sql
+++ b/flyway/migrations/V10__add_partially_graded_status_to_quiz_table.sql
@@ -1,0 +1,6 @@
+ALTER TABLE app.quizzes
+    DROP CONSTRAINT IF EXISTS chk_quiz_status;
+
+ALTER TABLE app.quizzes
+    ADD CONSTRAINT chk_quiz_status
+        CHECK (status IN ('generate_in_progress', 'not_started', 'submitted', 'partially_graded', 'graded'));

--- a/src/main/java/com/example/api/controller/QuizController.java
+++ b/src/main/java/com/example/api/controller/QuizController.java
@@ -480,8 +480,8 @@ public class QuizController extends BaseController {
                     })
                     .toList();
 
-            // createQuizResponse는 사용자가 답한 퀴즈 풀이를 생성하는 method
-            QuizResponseListOutput quizResponseListOutput = quizService.createQuizResponse(createQuizResponseListInput);
+            // submitAndGradeQuizWithStatus 문제 제출 및 채점, 상태관리까지
+            QuizResponseListOutput quizResponseListOutput = quizService.submitAndGradeQuizWithStatus(createQuizResponseListInput);
 
             // quizResponseOutputs의 각 quizResponseOutput을 SubmitQuizResponse 변환하여 정상 처리되었는지 status를 확인
             List<SubmitQuizResponse> submitQuizListResponse = quizResponseListOutput.getQuizResponseOutputs().stream()
@@ -490,9 +490,6 @@ public class QuizController extends BaseController {
             if (submitQuizListResponse.isEmpty()) {
                 return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
             }
-            
-            // quizService의 gradeQuiz를 호출
-            quizService.gradeQuiz(id);
             
             return ResponseEntity.ok(new SubmitQuizListResponse(submitQuizListResponse));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/example/api/entity/Quiz.java
+++ b/src/main/java/com/example/api/entity/Quiz.java
@@ -22,7 +22,7 @@ import java.util.UUID;
                 @Index(name = "idx_quizzes_lecture_updated_at", columnList = "lecture_id, updated_at")
         }
 )
-@Check(constraints = "status IN ('generate_in_progress', 'not_started', 'submitted', 'graded')")
+@Check(constraints = "status IN ('generate_in_progress', 'not_started', 'submitted', 'partially_graded', 'graded')")
 public class Quiz {
     @Id
     @Column()

--- a/src/main/java/com/example/api/entity/enums/Status.java
+++ b/src/main/java/com/example/api/entity/enums/Status.java
@@ -1,5 +1,5 @@
 package com.example.api.entity.enums;
 
 public enum Status {
-    generate_in_progress, not_started, submitted, graded
+    generate_in_progress, not_started, submitted, partially_graded, graded
 }

--- a/src/main/java/com/example/api/repository/QuizItemRepository.java
+++ b/src/main/java/com/example/api/repository/QuizItemRepository.java
@@ -5,9 +5,11 @@ import com.example.api.entity.QuizItem;
 import java.util.List;
 import java.util.UUID;
 
+import com.example.api.entity.enums.QuestionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface QuizItemRepository extends JpaRepository<QuizItem, UUID> {
     List<QuizItem> findByQuizId(UUID quizId);
+    boolean existsByQuizIdAndQuestionTypeAndDeletedAtIsNull(UUID quizId, QuestionType questionType);
 }

--- a/src/main/java/com/example/api/service/QuizService.java
+++ b/src/main/java/com/example/api/service/QuizService.java
@@ -26,8 +26,8 @@ public interface QuizService {
     void deleteQuiz(UUID quizId);
 
     @Transactional
-    QuizResponseListOutput createQuizResponse(List<CreateQuizResponseInput> inputs);
+    QuizResponseListOutput submitAndGradeQuizWithStatus(List<CreateQuizResponseInput> inputs);
     
     @Transactional
-    void gradeQuiz(UUID quizId);
+    void gradeNonEssayQuestions(UUID quizId);
 }

--- a/src/main/java/com/example/api/service/QuizServiceImpl.java
+++ b/src/main/java/com/example/api/service/QuizServiceImpl.java
@@ -28,13 +28,15 @@ public class QuizServiceImpl implements QuizService {
             QuizRepository quizRepo,
             QuizItemRepository quizItemRepo,
             LectureRepository lectureRepo,
-            QuizResponseRepository quizResponseRepo
+            QuizResponseRepository quizResponseRepo,
+            QuizResultRepository quizResultRepo
     ) {
         this.userRepo = userRepo;
         this.quizRepo = quizRepo;
         this.quizItemRepo = quizItemRepo;
         this.lectureRepo = lectureRepo;
         this.quizResponseRepo = quizResponseRepo;
+        this.quizResultRepo = quizResultRepo;
     }
 
     @Override
@@ -86,7 +88,7 @@ public class QuizServiceImpl implements QuizService {
 
     @Override
     @Transactional
-    public QuizResponseListOutput createQuizResponse(List<CreateQuizResponseInput> inputs) {
+    public QuizResponseListOutput submitAndGradeQuizWithStatus(List<CreateQuizResponseInput> inputs) {
         QuizResponseListOutput quizResponseListOutput = (QuizResponseListOutput) inputs.stream()
                 .map(input -> {
                     Quiz quiz = quizRepo.getReferenceById(input.getQuizId());
@@ -118,30 +120,55 @@ public class QuizServiceImpl implements QuizService {
 
                     return QuizResponseOutput.fromEntity(createdQuizResponse);
                 }).toList();
-        Quiz quiz = quizRepo.getReferenceById(inputs.get(0).getQuizId());
+        UUID quizId = inputs.get(0).getQuizId();
+        Quiz quiz = quizRepo.getReferenceById(quizId);
+
+        // 퀴즈 상태 'submitted'로 업데이트
         quiz.setStatus(Status.submitted);
         quizRepo.updateQuiz(quiz);
+
+        // 서술형 제외한 문제들 즉시 채점 및 QuizResult 생성
+        gradeNonEssayQuestions(quizId);
+
+        // 서술형 문제 유무에 따라 퀴즈 상태 'partially_graded', 'graded' 업데이트 다르게 처리
+        if (hasEssayQuestions(quizId)) {
+            quiz.setStatus(Status.partially_graded);
+            // TODO(jin): 서술형 채점 SQS 메시지 전송
+        } else {
+            quiz.setStatus(Status.graded);
+        }
+        quizRepo.updateQuiz(quiz);
+
         return quizResponseListOutput;
+    }
+
+    // 서술형 문제 존재 여부 확인 함수
+    private boolean hasEssayQuestions(UUID quizId) {
+        return quizItemRepo.existsByQuizIdAndQuestionTypeAndDeletedAtIsNull(quizId, QuestionType.essay);
     }
 
     @Override
     @Transactional
-    public void gradeQuiz(UUID quizId) {
+    public void gradeNonEssayQuestions(UUID quizId) {
         // 퀴즈 풀이와 퀴즈 아이템을 가져와서 답을 비교하여 점수 부여
         Quiz quiz = quizRepo.getReferenceById(quizId);
         List<QuizResponse> quizResponses = quizResponseRepo.findByQuizId(quizId);
 
         // 퀴즈 아이템의 questionType에 문제 유형을 확인하여 점수를 부여
-        float totalScore = 0;
+        float nonEssayScore = 0;
         for (QuizResponse quizResponse : quizResponses) {
             QuizItem quizItem = quizItemRepo.getReferenceById(quizResponse.getQuizItem().getId());
             if (quizItem.getQuestionType() == null) {
                 throw new IllegalArgumentException("Exam item question type cannot be null");
             }
+            // 서술형 문제는 이 함수에서 채점하지 않음
+            if(quizItem.getQuestionType() == QuestionType.essay) {
+                continue;
+            }
             if (quizItem.getQuestionType() == QuestionType.true_or_false) {
                 // true/false 문제
                 if (quizResponse.getSelectedBool() != null && quizResponse.getSelectedBool().equals(quizItem.getIsTrueAnswer())) {
-                    // totalScore += quizItem.getPoints();
+                    // nonEssayScore += quizItem.getPoints();
                     quizResponse.setIsCorrect(true);
                 }
             } else if (quizItem.getQuestionType() == QuestionType.multiple_choice) {
@@ -151,39 +178,33 @@ public class QuizServiceImpl implements QuizService {
                     Set<Integer> answerSet = new HashSet<>(Arrays.asList(quizItem.getAnswerIndices()));
                     
                     if (selectedSet.equals(answerSet)) {
-                        // totalScore += quizItem.getPoints();
+                        // nonEssayScore += quizItem.getPoints();
                         quizResponse.setIsCorrect(true);
                     }
                 }
             } else if (quizItem.getQuestionType() == QuestionType.short_answer) {
                 // 주관식 문제
                 if (quizResponse.getTextAnswer() != null && quizResponse.getTextAnswer().equals(quizItem.getTextAnswer())) {
-                    // totalScore += quizItem.getPoints();
+                    // nonEssayScore += quizItem.getPoints();
                     quizResponse.setIsCorrect(true);
                 }
             }
-            // TODO(jin): 서술형 문제 구현
 
-            // // 점수 부여
+            // 점수 부여
             // if (quizResponse.getIsCorrect()) {
             //     quizResponse.setScore(quizItem.getPoints());
-            //     totalScore += quizItem.getPoints();
+            //     nonEssayScore += quizItem.getPoints();
             // } else {
             //     quizResponse.setScore(0f);
             // }
             quizResponseRepo.updateQuizResponse(quizResponse);
         }
-        quiz.setStatus(Status.graded);
 
-        quizRepo.updateQuiz(quiz);
-
-        // 퀴즈 결과 생성 
-        // TODO(yoon) : 퀴즈 결과 생성 로직을 별개의 메서드로 분리
         QuizResult quizResult = new QuizResult();
         quizResult.setQuiz(quiz);
         quizResult.setUser(quizResponses.get(0).getUser());
-        quizResult.setScore(totalScore);
-        quizResult.setMaxScore(totalScore);
+        quizResult.setScore(nonEssayScore);
+        quizResult.setMaxScore(nonEssayScore);
         quizResult.setFeedback("Feedback");
         quizResult.setStartTime(quizResponses.get(0).getCreatedAt());
         quizResult.setEndTime(LocalDateTime.now());

--- a/src/test/java/com/example/api/controller/QuizControllerTest.java
+++ b/src/test/java/com/example/api/controller/QuizControllerTest.java
@@ -66,7 +66,7 @@ public class QuizControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
-    
+
     @MockBean
     private UserRepository userRepository;
 
@@ -158,7 +158,7 @@ public class QuizControllerTest {
         testQuizResponseListOutput.getQuizResponseOutputs().get(0).setUserId(userId);
         testQuizResponseListOutput.getQuizResponseOutputs().get(0).setQuizItemId(testQuizItems.get(0).getId());
     }
-    
+
     @Test
     @DisplayName("강의별 퀴즈 목록 조회")
     @WithMockUser
@@ -259,8 +259,8 @@ public class QuizControllerTest {
                 .andExpect(jsonPath("$.title", is("Quiz 1")));
 
         verify(quizService, times(1)).findQuizById(quizId);
-        verify(quizService, times(1)).updateQuiz(argThat(input -> 
-                input.getId().equals(quizId)    
+        verify(quizService, times(1)).updateQuiz(argThat(input ->
+                input.getId().equals(quizId)
                 && input.getTitle().equals("Updated Quiz Title")
         ));
     }
@@ -283,7 +283,7 @@ public class QuizControllerTest {
     @Test
     @DisplayName("퀴즈 응답 생성")
     @WithMockUser
-    void createQuizResponse() throws Exception {
+    void submitAndGradeQuiz() throws Exception {
         // given
         SubmitQuizRequest submitQuizRequest = new SubmitQuizRequest();
 
@@ -295,9 +295,9 @@ public class QuizControllerTest {
         testQuizResponse1.setQuiz(testQuiz);
 
         when(quizService.findQuizById(quizId)).thenReturn(Optional.of(testQuizOutput));
-        when(quizService.createQuizResponse(Mockito.<List<CreateQuizResponseInput>>any())).thenReturn(testQuizResponseListOutput);
-        
-        
+        when(quizService.submitAndGradeQuizWithStatus(Mockito.<List<CreateQuizResponseInput>>any())).thenReturn(testQuizResponseListOutput);
+
+
         submitQuizRequest.setSubmitQuizItems(List.of(
                 new SubmitQuizItem(),
                 new SubmitQuizItem()
@@ -310,7 +310,7 @@ public class QuizControllerTest {
         submitQuizRequest.getSubmitQuizItems().get(1).setSelectedIndices(new Integer[]{0, 1});
 
         when(quizService.findQuizById(quizId)).thenReturn(Optional.of(testQuizOutput));
-        when(quizService.createQuizResponse(Mockito.<List<CreateQuizResponseInput>>any())).thenReturn(testQuizResponseListOutput);
+        when(quizService.submitAndGradeQuizWithStatus(Mockito.<List<CreateQuizResponseInput>>any())).thenReturn(testQuizResponseListOutput);
 
         // when, then
         mockMvc.perform(post("/v1/quizzes/{id}/submit", quizId)
@@ -322,7 +322,7 @@ public class QuizControllerTest {
                 .andExpect(jsonPath("$.submitQuizResponses[0].userId", is(userId.toString())))
                 .andExpect(jsonPath("$.submitQuizResponses[0].quizItemId", is(testQuizItems.get(0).getId().toString())));
     }
-    
+
     @Test
     @DisplayName("유효하지 않은 요청으로 퀴즈 생성")
     @WithMockUser
@@ -348,7 +348,7 @@ public class QuizControllerTest {
         verify(quizService, never()).createQuiz(any(CreateQuizInput.class));
         verify(sqsClient, never()).sendGenerateQuizMessage(any());
     }
-    
+
     @Test
     @DisplayName("존재하지 않는 강의로 퀴즈 생성")
     @WithMockUser

--- a/src/test/java/com/example/api/service/QuizServiceTest.java
+++ b/src/test/java/com/example/api/service/QuizServiceTest.java
@@ -288,23 +288,19 @@ public class QuizServiceTest {
 
         // Item 3: short answer
         when(quizItemRepository.getReferenceById(quizItemId3)).thenReturn(testQuizResponses.get(2).getQuizItem());
-
-        when(quizRepository.updateQuiz(any(Quiz.class))).thenReturn(testQuiz);
+        // 변경: updateQuiz 제거 (gradeNonEssayQuestions는 퀴즈 상태를 직접 업데이트하지 않음)
         when(quizResponseRepository.updateQuizResponse(any(QuizResponse.class))).thenReturn(new QuizResponse());
         when(quizResultRepository.createQuizResult(any(QuizResult.class))).thenReturn(new QuizResult());
 
         // when
-        quizService.gradeQuiz(quizId);
+        quizService.gradeNonEssayQuestions(quizId);
 
         // then
         verify(quizRepository, times(1)).getReferenceById(quizId);
         verify(quizResponseRepository, times(1)).findByQuizId(quizId);
         verify(quizItemRepository, times(3)).getReferenceById(any(UUID.class));
 
-        // Verify quiz status is updated to graded
-        verify(quizRepository).updateQuiz(quizCaptor.capture());
-        Quiz capturedQuiz = quizCaptor.getValue();
-        assertEquals(Status.graded, capturedQuiz.getStatus());
+        // 변경: 퀴즈 상태 업데이트 검증 제거 (gradeNonEssayQuestions는 퀴즈 상태를 직접 업데이트하지 않음)
 
         // Verify each response is updated with correct isCorrect flag
         verify(quizResponseRepository, times(3)).updateQuizResponse(quizResponseCaptor.capture());
@@ -341,35 +337,25 @@ public class QuizServiceTest {
         // Item 3: short answer
         when(quizItemRepository.getReferenceById(quizItemId3)).thenReturn(testQuizResponses.get(2).getQuizItem());
 
-        when(quizRepository.updateQuiz(any(Quiz.class))).thenReturn(testQuiz);
         when(quizResponseRepository.updateQuizResponse(any(QuizResponse.class))).thenReturn(new QuizResponse());
         when(quizResultRepository.createQuizResult(any(QuizResult.class))).thenReturn(new QuizResult());
 
         // when
-        quizService.gradeQuiz(quizId);
+        quizService.gradeNonEssayQuestions(quizId);
 
         // then
         verify(quizRepository, times(1)).getReferenceById(quizId);
         verify(quizResponseRepository, times(1)).findByQuizId(quizId);
         verify(quizItemRepository, times(3)).getReferenceById(any(UUID.class));
 
-        // Verify quiz status is updated to graded
-        verify(quizRepository).updateQuiz(quizCaptor.capture());
-        Quiz capturedQuiz = quizCaptor.getValue();
-        assertEquals(Status.graded, capturedQuiz.getStatus());
+        // 변경: 퀴즈 상태 업데이트 검증 제거 (gradeNonEssayQuestions는 퀴즈 상태를 직접 업데이트하지 않음)
 
         // Verify each response is updated
         verify(quizResponseRepository, times(3)).updateQuizResponse(quizResponseCaptor.capture());
         List<QuizResponse> capturedResponses = quizResponseCaptor.getAllValues();
 
-        // The first two responses should NOT be marked as correct, but the third one should be
-        assertEquals(testQuizResponses.get(0).getId(), capturedResponses.get(0).getId());
-        assertEquals(Boolean.FALSE, capturedResponses.get(0).getIsCorrect()); // Wrong answer
-
-        assertEquals(testQuizResponses.get(1).getId(), capturedResponses.get(1).getId());
-        assertEquals(Boolean.FALSE, capturedResponses.get(1).getIsCorrect()); // Wrong answer
-
-        assertEquals(testQuizResponses.get(2).getId(), capturedResponses.get(2).getId());
+        assertEquals(Boolean.FALSE, capturedResponses.get(0).getIsCorrect()); // Wrong answer - set to false
+        assertEquals(Boolean.FALSE, capturedResponses.get(1).getIsCorrect()); // Wrong answer - set to false
         assertEquals(Boolean.TRUE, capturedResponses.get(2).getIsCorrect()); // Correct
 
         // Verify quiz result is created
@@ -390,13 +376,13 @@ public class QuizServiceTest {
         when(quizItemRepository.getReferenceById(quizItemId1)).thenReturn(testQuizResponses.get(0).getQuizItem());
 
         // when, then
-        assertThrows(IllegalArgumentException.class, () -> quizService.gradeQuiz(quizId));
+        assertThrows(IllegalArgumentException.class, () -> quizService.gradeNonEssayQuestions(quizId));
 
         verify(quizRepository, times(1)).getReferenceById(quizId);
         verify(quizResponseRepository, times(1)).findByQuizId(quizId);
         verify(quizItemRepository, times(1)).getReferenceById(quizItemId1);
         verify(quizResponseRepository, never()).updateQuizResponse(any(QuizResponse.class));
-        verify(quizRepository, never()).updateQuiz(any(Quiz.class));
+        // 변경: updateQuiz 제거 (gradeNonEssayQuestions는 퀴즈 상태를 직접 업데이트하지 않음)
         verify(quizResultRepository, never()).createQuizResult(any(QuizResult.class));
     }
 }


### PR DESCRIPTION
# Ticket

task-x-x-x

# Slack

https://sc25hq.slack.com/archives/C08G041EFRV/p1748751484307289?thread_ts=1748665853.815969&cid=C08G041EFRV
https://sc25hq.slack.com/archives/C08G041EFRV/p1748760221475459?thread_ts=1748701274.782069&cid=C08G041EFRV

# Description

Quiz status enum에 partially_graded를 추가하고, 
QuizResult 생성 시점을 서술형 문제 채점 후가 아닌 서술형 제외 모든 문제 채점 후로 변경해요.

# Checklist

- V10 마이그레이션 필요합니다.
- 모의시험(exam)관해서는 동일한 코드변경이 필요한데 아직 수행하지 않았어요.
- @IMHNJN 일단 현준님 코드 최대한 덜 변경하는 선에서 로직만 수정했는데요, 그래서 dto는 건드리지 않았습니다. 
지금 하고계시는 퀴즈 조회 API, 퀴즈 채점 결과 조회 API 먼저 수정하시고, 
저도 서술형 채점 람다 job QuizServiceImpl에 추가하고 나서 
그 때 더 깔끔한 구조 있나 리팩토링해봐도 괜찮을 것 같습니다. (option)
- 그리고 서비스 함수 gradeQuiz에서 gradeNonEssayQuestions로 객관식, o/x, 단답형만 채점하는 함수로 바꿨는데 점수 관련해서는 주석처리하셨더라구요. 아마 점수 결정 전이었어서 그러셨던 것 같은데 이것도 조회 API 하신 다음 수정해주시면 될 것 같습니다. 