### PR TITLE
chore: add studyaid.academy domain to CORS allowed origins

### DIFF
--- a/src/main/java/com/example/api/config/SecurityConfig.java
+++ b/src/main/java/com/example/api/config/SecurityConfig.java
@@ -50,12 +50,15 @@ public class SecurityConfig {
                 .build();
     }
 
+    // TODO(jin): CORS 설정 별도 CONFIG로 분리
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList(
                 "http://localhost:3000",
-                "http://studyaid-dev-alb-1539956535.ap-northeast-2.elb.amazonaws.com"
+                "http://studyaid-dev-alb-1539956535.ap-northeast-2.elb.amazonaws.com",
+                "https://studyaid.academy",
+                "https://www.studyaid.academy"
                 //필요시 도메인 추가
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));


### PR DESCRIPTION
# Ticket

task-0-2-9 메일 전송 위한 AWS SES 인증/도메인 셋업

# Slack

# Description

https://studyaid.academy
https://www.studyaid.academy
를 CORS allowed origins에 추가해요.

# Checklist

CORS 설정 별도 config로 분리하는 것은 일단 지금 다른 작업부터 해야할 것 같아서 TODO로 남겨놓았습니다.