### PR TITLE
feat: add references column and update QnA GET /messages /liked APIs

### DIFF
--- a/flyway/migrations/V12__add_references_to_qna_chat_messages.sql
+++ b/flyway/migrations/V12__add_references_to_qna_chat_messages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE app.qna_chat_messages
+    ADD COLUMN reference_chunks JSONB;

--- a/src/main/java/com/example/api/controller/QnaChatController.java
+++ b/src/main/java/com/example/api/controller/QnaChatController.java
@@ -183,6 +183,7 @@ public class QnaChatController {
                         m.getMessageId(),
                         m.getRole(),
                         m.getContent(),
+                        m.getReferences(),
                         m.getCreatedAt(),
                         m.isLiked()
                 ))
@@ -237,6 +238,7 @@ public class QnaChatController {
                         m.getMessageId(),
                         m.getRole(),
                         m.getContent(),
+                        m.getReferences(),
                         m.getCreatedAt(),
                         m.isLiked()
                 ))

--- a/src/main/java/com/example/api/controller/dto/qna/GetLikedMessagesResponse.java
+++ b/src/main/java/com/example/api/controller/dto/qna/GetLikedMessagesResponse.java
@@ -1,5 +1,6 @@
 package com.example.api.controller.dto.qna;
 
+import com.example.api.external.dto.langchain.ReferenceResponse;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
@@ -28,6 +29,7 @@ public class GetLikedMessagesResponse {
         private String role;
         @NotNull
         private String content;
+        private List<ReferenceResponse.ReferenceChunkResponse> references;
         @NotNull
         private LocalDateTime createdAt;
         @NotNull

--- a/src/main/java/com/example/api/controller/dto/qna/GetQnaChatMessagesResponse.java
+++ b/src/main/java/com/example/api/controller/dto/qna/GetQnaChatMessagesResponse.java
@@ -1,7 +1,9 @@
 package com.example.api.controller.dto.qna;
 
+import com.example.api.external.dto.langchain.ReferenceResponse;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,6 +21,7 @@ public class GetQnaChatMessagesResponse {
     private List<MessageItem> messages;
     @NotNull
     private boolean hasMore;
+    @Nullable
     private UUID nextCursor; // 메세지가 아예 없거나, 더 가져올 메세지가 없는 경우 (hasMore가 false인 경우) Null일 수 있음
 
     @Getter
@@ -31,6 +34,8 @@ public class GetQnaChatMessagesResponse {
         private String role;
         @NotNull
         private String content;
+        @Nullable
+        private List<ReferenceResponse.ReferenceChunkResponse> references;
         @NotNull
         private LocalDateTime createdAt;
         @NotNull

--- a/src/main/java/com/example/api/entity/QnaChatMessage.java
+++ b/src/main/java/com/example/api/entity/QnaChatMessage.java
@@ -1,12 +1,16 @@
 package com.example.api.entity;
 
 import com.example.api.entity.enums.MessageRole;
+import com.example.api.external.dto.langchain.ReferenceResponse;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -39,6 +43,10 @@ public class QnaChatMessage {
 
     @Column(name = "content")
     private String content;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "reference_chunks", columnDefinition = "jsonb") // references가 postgres 예약어라서 db에서는 reference_chunks로 저장
+    private List<ReferenceResponse.ReferenceChunkResponse> references;
 
     @Column(name = "is_liked", nullable = false)
     private Boolean isLiked;

--- a/src/main/java/com/example/api/service/QnaChatServiceImpl.java
+++ b/src/main/java/com/example/api/service/QnaChatServiceImpl.java
@@ -190,6 +190,7 @@ public class QnaChatServiceImpl implements QnaChatService {
         botMsg.setUser(user);
         botMsg.setRole(MessageRole.ASSISTANT);
         botMsg.setContent(answer);
+        botMsg.setReferences(referenceChunks);
         botMsg = qnaChatMessageRepository.save(botMsg);
         log.info("[Performance] AI 답변 DB에 저장 완료: 소요시간={}ms", System.currentTimeMillis() - saveAnswerStartTime);
 
@@ -250,6 +251,7 @@ public class QnaChatServiceImpl implements QnaChatService {
                             m.getId(),
                             m.getRole().getValue(),
                             m.getContent(),
+                            m.getRole() == MessageRole.ASSISTANT ? m.getReferences() : null,
                             m.getCreatedAt(),
                             isLiked
                     );
@@ -271,6 +273,7 @@ public class QnaChatServiceImpl implements QnaChatService {
                         message.getId(),
                         message.getRole().getValue(),
                         message.getContent(),
+                        message.getReferences(),
                         message.getCreatedAt(),
                         true
                 ))

--- a/src/main/java/com/example/api/service/dto/qna/GetLikedMessagesOutput.java
+++ b/src/main/java/com/example/api/service/dto/qna/GetLikedMessagesOutput.java
@@ -1,6 +1,6 @@
 package com.example.api.service.dto.qna;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.example.api.external.dto.langchain.ReferenceResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -20,6 +20,7 @@ public class GetLikedMessagesOutput {
         private UUID messageId;
         private String role;
         private String content;
+        private List<ReferenceResponse.ReferenceChunkResponse> references;
         private LocalDateTime createdAt;
         private boolean isLiked;
     }

--- a/src/main/java/com/example/api/service/dto/qna/GetQnaChatMessagesOutput.java
+++ b/src/main/java/com/example/api/service/dto/qna/GetQnaChatMessagesOutput.java
@@ -1,5 +1,7 @@
 package com.example.api.service.dto.qna;
 
+import com.example.api.external.dto.langchain.ReferenceResponse;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,6 +29,8 @@ public class GetQnaChatMessagesOutput {
         private UUID messageId;
         private String role;
         private String content;
+        @Nullable
+        private List<ReferenceResponse.ReferenceChunkResponse> references;
         private LocalDateTime createdAt;
         private boolean isLiked;
     }

--- a/src/test/java/com/example/api/controller/QnaChatControllerTest.java
+++ b/src/test/java/com/example/api/controller/QnaChatControllerTest.java
@@ -107,10 +107,12 @@ class QnaChatControllerTest {
         // Given
         List<GetQnaChatMessagesOutput.MessageItem> messages = List.of(
                 new GetQnaChatMessagesOutput.MessageItem(
-                        UUID.randomUUID(), "user", "재귀 함수란 무엇인가요?", LocalDateTime.now(), false
+                        UUID.randomUUID(), "user", "재귀 함수란 무엇인가요?",null, LocalDateTime.now(), false
                 ),
                 new GetQnaChatMessagesOutput.MessageItem(
-                        MESSAGE_ID, "assistant", "재귀 함수는 자기 자신을 호출하는 함수입니다.", LocalDateTime.now(), true
+                        MESSAGE_ID, "assistant", "재귀 함수는 자기 자신을 호출하는 함수입니다.",
+                        List.of(new ReferenceResponse.ReferenceChunkResponse("출처1", 42)),
+                        LocalDateTime.now(), true
                 )
         );
 
@@ -136,9 +138,13 @@ class QnaChatControllerTest {
                 .andExpect(jsonPath("$.messages[0].role").value("user"))
                 .andExpect(jsonPath("$.messages[0].content").value("재귀 함수란 무엇인가요?"))
                 .andExpect(jsonPath("$.messages[0].isLiked").value(false))
+                .andExpect(jsonPath("$.messages[0].references").doesNotExist())
                 .andExpect(jsonPath("$.messages[1].role").value("assistant"))
                 .andExpect(jsonPath("$.messages[1].content").value("재귀 함수는 자기 자신을 호출하는 함수입니다."))
                 .andExpect(jsonPath("$.messages[1].isLiked").value(true))
+                .andExpect(jsonPath("$.messages[1].references").isArray())
+                .andExpect(jsonPath("$.messages[1].references[0].text").value("출처1"))
+                .andExpect(jsonPath("$.messages[1].references[0].page").value(42))
                 .andExpect(jsonPath("$.hasMore").value(false))
                 .andExpect(jsonPath("$.nextCursor").value(nextCursor.toString()));
     }
@@ -150,7 +156,9 @@ class QnaChatControllerTest {
         // Given
         List<GetLikedMessagesOutput.LikedMessageItem> likedMessages = List.of(
                 new GetLikedMessagesOutput.LikedMessageItem(
-                        MESSAGE_ID, "assistant", "재귀 함수는 자기 자신을 호출하는 함수입니다.", LocalDateTime.now(), true
+                        MESSAGE_ID, "assistant", "재귀 함수는 자기 자신을 호출하는 함수입니다.",
+                        List.of(new ReferenceResponse.ReferenceChunkResponse("출처1", 42)),
+                        LocalDateTime.now(), true
                 )
         );
 
@@ -166,7 +174,9 @@ class QnaChatControllerTest {
                 .andExpect(jsonPath("$.chatId").value(CHAT_ID.toString()))
                 .andExpect(jsonPath("$.messages").exists())
                 .andExpect(jsonPath("$.messages[0].role").value("assistant"))
-                .andExpect(jsonPath("$.messages[0].isLiked").value(true));
+                .andExpect(jsonPath("$.messages[0].isLiked").value(true))
+                .andExpect(jsonPath("$.messages[0].references").isArray())
+                .andExpect(jsonPath("$.messages[0].references[0].text").value("출처1"));
     }
 
     @Test

--- a/src/test/java/com/example/api/service/QnaChatServiceTest.java
+++ b/src/test/java/com/example/api/service/QnaChatServiceTest.java
@@ -136,6 +136,7 @@ public class QnaChatServiceTest {
         message1.setContent("재귀 함수란 무엇인가요?");
         message1.setCreatedAt(LocalDateTime.now());
         message1.setIsLiked(false);
+        message1.setReferences(null);
 
         QnaChatMessage message2 = new QnaChatMessage();
         message2.setId(TEST_MESSAGE_ID);
@@ -143,12 +144,13 @@ public class QnaChatServiceTest {
         message2.setContent("재귀 함수는 자기 자신을 호출하는 함수입니다.");
         message2.setCreatedAt(LocalDateTime.now());
         message2.setIsLiked(true);
+        message2.setReferences(List.of(new ReferenceResponse.ReferenceChunkResponse("출처1", 42)));
 
-        when(qnaChatMessageRepository.findByQnaChatIdWithCursor(eq(TEST_CHAT_ID), eq(TEST_MESSAGE_ID), eq(5)))
+        when(qnaChatMessageRepository.findByQnaChatIdWithCursor(eq(TEST_CHAT_ID), eq(TEST_MESSAGE_ID), eq(20)))
                 .thenReturn(List.of(message1, message2));
 
         // When
-        GetQnaChatMessagesInput input = new GetQnaChatMessagesInput(TEST_LECTURE_ID, TEST_USER_ID, TEST_MESSAGE_ID, 5);
+        GetQnaChatMessagesInput input = new GetQnaChatMessagesInput(TEST_LECTURE_ID, TEST_USER_ID, TEST_MESSAGE_ID, 20);
         GetQnaChatMessagesOutput output = qnaChatService.getMessages(input);
 
         // Then
@@ -160,9 +162,13 @@ public class QnaChatServiceTest {
         assertNotNull(output.getMessages().get(0).getMessageId());
         assertNotNull(output.getMessages().get(0).getCreatedAt());
         assertFalse(output.getMessages().get(0).isLiked());
+        assertNull(output.getMessages().get(0).getReferences());
         assertEquals("assistant", output.getMessages().get(1).getRole());
         assertEquals("재귀 함수는 자기 자신을 호출하는 함수입니다.", output.getMessages().get(1).getContent());
         assertTrue(output.getMessages().get(1).isLiked());
+        assertNotNull(output.getMessages().get(1).getReferences());
+        assertEquals(1, output.getMessages().get(1).getReferences().size());
+        assertEquals("출처1", output.getMessages().get(1).getReferences().get(0).getText());
     }
 
     @Test
@@ -315,6 +321,7 @@ public class QnaChatServiceTest {
         likedMessage.setContent("재귀 함수는 자기 자신을 호출하는 함수입니다.");
         likedMessage.setCreatedAt(LocalDateTime.now());
         likedMessage.setIsLiked(true);
+        likedMessage.setReferences(List.of(new ReferenceResponse.ReferenceChunkResponse("출처1", 42)));
 
         when(qnaChatRepository.findByLectureIdAndUserId(TEST_LECTURE_ID, TEST_USER_ID))
                 .thenReturn(Optional.of(testQnaChat));
@@ -333,5 +340,8 @@ public class QnaChatServiceTest {
         assertEquals("assistant", output.getMessages().get(0).getRole());
         assertEquals("재귀 함수는 자기 자신을 호출하는 함수입니다.", output.getMessages().get(0).getContent());
         assertTrue(output.getMessages().get(0).isLiked());
+        assertNotNull(output.getMessages().get(0).getReferences());
+        assertEquals(1, output.getMessages().get(0).getReferences().size());
+        assertEquals("출처1", output.getMessages().get(0).getReferences().get(0).getText());
     }
 }


### PR DESCRIPTION
# Ticket

task-x-x-x

# Slack

https://sc25hq.slack.com/archives/C08G041EFRV/p1749037046517459

# Description

qna_chat_messages 테이블에 references 컬럼을 추가하고 
전체 메시지 조회, 좋아요 한 메세지 조회 응답에 references를 추가합니다. 

# Checklist

V12 마이그레이션 필요합니다. 